### PR TITLE
move to luau-lsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A command-line tool for bundling and analyzing Luau files. This tool provides a 
 ## Features
 
 - **Bundling**: Bundle Luau files with configurable output formats
-- **Analysis**: Analyze Luau files with luau-analyze
+- **Analysis**: Analyze Luau files with luau-lsp
 - **Generate Completions**: Generate completions for the CLI
 - **Platform Organization**: Organize your Luau modules by platform and flows
 - **Configurable**: Easy-to-use TOML configuration

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub output_directory: String,
+    pub definition_files: Option<Vec<String>>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ enum Commands {
     },
 }
 
-fn check_luau_analyze() -> Result<()> {
-    which("luau-analyze").context("luau-analyze is not installed. Please install it first")?;
+fn check_luau_lsp() -> Result<()> {
+    which("luau-lsp").context("luau-lsp is not installed. Please install it first (https://github.com/JohnnyMorganz/luau-lsp/releases)")?;
     Ok(())
 }
 
@@ -144,15 +144,20 @@ fn bundle(config_path: &str) -> Result<()> {
 }
 
 fn analyze(config_path: &str) -> Result<()> {
-    check_luau_analyze()?;
+    check_luau_lsp()?;
     let config = config::Config::from_file(config_path)?;
 
     let execution_dir = env::current_dir()?;
 
+    let definition_files = config.settings.definition_files.clone().unwrap_or_default();
+    let definition_files_args = definition_files.iter().flat_map(|file| ["--definitions".to_string(), file.to_string()]).collect::<Vec<String>>();
+
     let file_paths = config.get_flows_paths();
 
-    std::process::Command::new("luau-analyze")
+    std::process::Command::new("luau-lsp")
         .current_dir(execution_dir.clone())
+        .arg("analyze")
+        .args(&definition_files_args)
         .args(&file_paths)
         .status()?;
 


### PR DESCRIPTION
Using `luau-lsp` for analyzing and giving it our definition file we don't have a need for `.luaurc` anymore