### PR TITLE
update darklua version 0.16.0 -> 0.17.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ clap = { version = "4.5.1", features = ["derive", "cargo"] }
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8.20"
 which = "7.0.2"
-darklua = "0.16.0"
+darklua = "0.17.1"
 serde_derive = "1.0.217"
 clap_complete = "4.5.46"
 axum = "0.8.3"


### PR DESCRIPTION
This is needed. I think the guys from darklua changed a few things, and now the files are not exactly the same, so when we compute the hashes and check them against an older version, it fucks up. This is related to #14 which also updates the darklua version and I get errors when running tests in the managed-flows repo https://github.com/OpacityLabs/managed-flows/actions/runs/17243928574/job/48928501292