### PR TITLE
feat: rebundle flow on request

### DIFF
--- a/src/commands/analyze.rs
+++ b/src/commands/analyze.rs
@@ -9,7 +9,6 @@ fn check_luau_lsp() -> Result<()> {
     Ok(())
 }
 
-
 pub fn analyze(config_path: &str) -> Result<()> {
     check_luau_lsp()?;
     let config = config::Config::from_file(config_path)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,6 +19,30 @@ pub struct Platform {
     pub flows: Vec<Flow>,
 }
 
+#[derive(Debug, Clone)]
+pub struct SimplePlatform {
+    pub name: String,
+    pub description: String,
+}
+
+impl From<Platform> for SimplePlatform {
+    fn from(platform: Platform) -> Self {
+        Self {
+            name: platform.name,
+            description: platform.description,
+        }
+    }
+}
+
+impl From<&Platform> for SimplePlatform {
+    fn from(platform: &Platform) -> Self {
+        Self {
+            name: platform.name.clone(),
+            description: platform.description.clone(),
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Flow {
     pub name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,19 +1,19 @@
 pub mod config;
 mod commands {
-    pub mod serve;
-    pub mod bundle;
     pub mod analyze;
+    pub mod bundle;
     pub mod generate_completions;
+    pub mod serve;
 }
 
-use commands::serve::serve;
-use commands::bundle::bundle;
 use commands::analyze::analyze;
 use commands::generate_completions::generate_completions;
 
-use anyhow::{Result};
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use tracing::Level;
+
+use crate::commands::{bundle::bundle, serve::serve};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
@@ -40,11 +40,11 @@ enum Commands {
         shell: String,
     },
 
-    /// Serve Lua flows over HTTP
+    /// Serve Lua flows over HTTP (and rebundle only the requested flow, if rebundle is enabled)
     Serve {
-        /// Watch for file changes and rebundle/restart
+        /// Rebundle only the requested flow, if rebundle is enabled
         #[arg(short, long)]
-        watch: bool,
+        rebundle: bool,
     },
 }
 
@@ -54,7 +54,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error>> {
         Commands::Bundle => bundle(&cli.config, false)?,
         Commands::Analyze => analyze(&cli.config)?,
         Commands::GenerateCompletions { shell } => generate_completions(shell)?,
-        Commands::Serve { watch } => serve(&cli.config, watch).await?,
+        // Commands::Serve { watch } => serve(&cli.config, watch).await?,
+        Commands::Serve { rebundle } => serve(&cli.config, *rebundle).await?,
     }
     Ok(())
 }


### PR DESCRIPTION
This PR changes the `serve` command to have the `--rebundle` argument instead of the `--watch` argument and to compile/bundle the specific requested flow on every request (good for devving)